### PR TITLE
add --json flag to analyze command

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -144,7 +144,11 @@ def version():
 
 # SPICE ANALYZE COMMAND
 @app.command()
-def analyze(file: str):
+def analyze(
+    file: str, 
+    all: bool = typer.Option(False, "--all", help="Analyze all stats without selection menu"),
+    json_output: bool = typer.Option(False, "--json", help="Output results in JSON format")
+):
     """
     Analyze the given file.
     """
@@ -152,57 +156,79 @@ def analyze(file: str):
     # load translations
     messages = get_translation()
 
-    # define available stats UPDATE THIS WHEN  NEEDED PLEASE !!!!!!!!
+    # define available stats UPDATE THIS WHEN NEEDED PLEASE !!!!!!!!
     available_stats = [
         "line_count",
         "function_count", 
         "comment_line_count"
     ]
 
-    # dicionary for the stats UPDATE THIS WHEN  NEEDED PLEASE !!!!!!!!
+    # dictionary for the stats UPDATE THIS WHEN NEEDED PLEASE !!!!!!!!
     stats_labels = {
         "line_count": messages.get("line_count_option", "Line Count"),
         "function_count": messages.get("function_count_option", "Function Count"),
         "comment_line_count": messages.get("comment_line_count_option", "Comment Line Count")
     }
     
+    # If --all flag is used, skip the selection menu and use all stats
+    if all:
+        selected_stat_keys = available_stats
+    else:
+        # Don't show interactive menu in JSON mode (assumes all stats)
+        if json_output:
+            selected_stat_keys = available_stats
+        else:
+            # print checkbox menu to select which stats to show
+            selected_stats = inquirer.checkbox(
+                message=messages.get("select_stats", "Select stats to display:"),
+                choices=[stats_labels[stat] for stat in available_stats],
+                pointer="> ",
+                default=[stats_labels[stat] for stat in available_stats],  # All selected by default
+                instruction=messages.get("checkbox_hint", "(Use space to select, enter to confirm)")
+            ).execute()
 
-    # print checkbox menu to select which stats to show
-    selected_stats = inquirer.checkbox(
-        message=messages.get("select_stats", "Select stats to display:"),
-        choices=[stats_labels[stat] for stat in available_stats],
-        pointer="> ",
-        default=[stats_labels[stat] for stat in available_stats],  # All selected by default
-        instruction=messages.get("checkbox_hint", "(Use space to select, enter to confirm)")
-    ).execute()
+            # if no stats were selected
+            if not selected_stats:
+                if json_output:
+                    import json
+                    print(json.dumps({"error": messages.get("no_stats_selected", "No stats selected. Analysis cancelled.")}))
+                else:
+                    print(messages.get("no_stats_selected", "No stats selected. Analysis cancelled."))
+                return
 
-
-    # if no stats were selected
-    if not selected_stats:
-        print(messages.get("no_stats_selected", "No stats selected. Analysis cancelled."))
-        return
-
-    # create a mapping from displayed labels back to stat keys
-    reverse_mapping = {v: k for k, v in stats_labels.items()}
-    
-    # convert selected labels back to stat keys
-    selected_stat_keys = [reverse_mapping[label] for label in selected_stats]
+            # create a mapping from displayed labels back to stat keys
+            reverse_mapping = {v: k for k, v in stats_labels.items()}
+            
+            # convert selected labels back to stat keys
+            selected_stat_keys = [reverse_mapping[label] for label in selected_stats]
 
     # try to analyze and if error then print the error
     try:
-        # show analyzing message
-        print(f"{messages['analyzing_file']}: {file}")
+        # show analyzing message if not in JSON mode
+        if not json_output:
+            print(f"{messages['analyzing_file']}: {file}")
         
         # get analysis results from analyze_file
         results = analyze_file(file, selected_stats=selected_stat_keys)
         
-        # only print the selected stats
-        for stat in selected_stat_keys:
-            if stat in results:
-                print(messages[stat].format(count=results[stat]))
+        # output in JSON format if flag
+        if json_output:
+            import json
+            # Add filename to results
+            results["filename"] = file
+            print(json.dumps(results, indent=2))
+        else:
+            # only print the selected stats in normal mode
+            for stat in selected_stat_keys:
+                if stat in results:
+                    print(messages[stat].format(count=results[stat]))
         
     except Exception as e:
-        print(f"[red]{messages['error']}[/] {e}")
+        if json_output:
+            import json
+            print(json.dumps({"error": str(e)}))
+        else:
+            print(f"[red]{messages['error']}[/] {e}")
 
 
 def main():

--- a/cli/main.py
+++ b/cli/main.py
@@ -214,8 +214,6 @@ def analyze(
         # output in JSON format if flag
         if json_output:
             import json
-            # Add filename to results
-            results["filename"] = file
             print(json.dumps(results, indent=2))
         else:
             # only print the selected stats in normal mode


### PR DESCRIPTION
adicionar flag --json no comando analyze ele faz o output em json e se vc usar a flag --json ele automaticamente usa a flag --all tambem

exemplo de uso:
```
spice analyze example.py --json
```

exemplo de output:
```json
{
  "file_name": "example.py",
  "line_count": 19,       
  "comment_line_count": 2,
  "function_count": 0,    
}
```